### PR TITLE
Adapt logging format to new DDNet

### DIFF
--- a/operations/parser.go
+++ b/operations/parser.go
@@ -33,16 +33,16 @@ var log = logging.MustGetLogger("main")
  * Parse econ log statements.
  * Contains logic to evaluate/act upon any incoming logs coming from the econ.
  *
- * Abstract:	"[TYPE]: INFORMATION"
+ * Abstract:	"L TYPE: INFORMATION"
  * Into:			result[1]: "CATEGORY"
  *						result[2]: "CONTENT"
  *
- * Example:	  "[register]: ERROR: the master server..."
+ * Example:	  "i register: ERROR: the master server..."
  * Into:			result[1]: "register",
  *						result[2]: "ERROR: the master server..."
  */
 func (c Controller) Parse(input string) {
-	reg := regexp.MustCompile(`\[(\w+)\]: (.+)`)
+	reg := regexp.MustCompile(`\w (\w+): (.+)`)
 	result := reg.FindStringSubmatch(input)
 	category, content := result[1], result[2]
 

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-while true; do ./infclass-stats && break; done
+while true; do ./infclass-stats && break; sleep 3; done


### PR DESCRIPTION
DDNet have changed they logging format. When infclass_stats attempt to
parse it, the script crashes, immediately restarts and connects to the server
again, causing DOS.

Also, when the script fails for some reason, the loop starts it again. It might cause DoS on the infclass server.

Do not re-launch the server immediately, instead, wait for 3 seconds.